### PR TITLE
Simplify the demo: Changed docker script to exit from the demo just after small data training finished #5

### DIFF
--- a/docker/smalltrain/run_smalltrain.sh
+++ b/docker/smalltrain/run_smalltrain.sh
@@ -11,7 +11,15 @@ echo "Exec operation id: ${OPERATION_ID}"
 # For Sequential processing
 /var/smalltrain/tutorials/image_recognition/operation_tutorials.sh $OPERATION_ID
 
+exit
+
 # 2. Training example
+# If you want to experiment training CIFAR-10, execute these operations
+# - Training from restored model
+#    OPERATION_ID=IR_2D_CNN_V2_l49-c64_TUTORIAL-20200708-TRAIN
+# - Zero base training
+#    OPERATION_ID=IR_2D_CNN_V2_l49-c64_TUTORIAL-ZEROBASE-TRAIN
+
 # Training from restored model
 OPERATION_ID=IR_2D_CNN_V2_l49-c64_TUTORIAL-20200708-TRAIN
 # Zero base training


### PR DESCRIPTION
デモの簡素化。スモールデータによる学習が終わったら、デモを終わらせる(スクリプトをexitする)よう変更